### PR TITLE
use new esm version of uibuilder

### DIFF
--- a/uibuilder/vue3-app/package.json
+++ b/uibuilder/vue3-app/package.json
@@ -7,14 +7,14 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "node-red-contrib-uibuilder": "^4.1.4",
+    "node-red-contrib-uibuilder": "^5.1.1",
     "socket.io-client": "^4.4.1",
     "vue": "^3.2.25"
   },
   "devDependencies": {
-    "@vitejs/plugin-vue": "^2.0.0",
+    "@vitejs/plugin-vue": "^3.0.0",
     "typescript": "^4.4.4",
-    "vite": "^2.7.2",
+    "vite": "^3.0.0",
     "vue-tsc": "^0.29.8"
   }
 }

--- a/uibuilder/vue3-app/src/plugin/uibuilderPlugin.ts
+++ b/uibuilder/vue3-app/src/plugin/uibuilderPlugin.ts
@@ -1,6 +1,6 @@
 import { App, provide, reactive, ref } from 'vue'
 // @ts-ignore
-import uibuilder from 'node-red-contrib-uibuilder/front-end/src/uibuilderfe.js'
+import uibuilder from 'node-red-contrib-uibuilder/front-end/uibuilder.esm.js'
 import IData from '../interface/IData';
 
 


### PR DESCRIPTION
The old client library is no longer updated, and the new one seems to work with your app just fine-- here's a small patch for the vue3 app.